### PR TITLE
Add text.xml.svg to default grammars

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,6 +28,7 @@ module.exports =
       default: [
         'text.plain.null-grammar'
         'text.xml'
+        'text.xml.svg'
       ]
 
   activate: ->


### PR DESCRIPTION
The preview wasn't working for me, and ofter some debugging, it turns out the SVG grammar is slightly different.

I don't know if this is because of a particular SVG file (I tested 4 different files) or because I'm running Linux (or something else), but the grammar was `text.xml.svg` instead of `text.xml`.