### PR TITLE
Update dependendencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "atom": ">0.200.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.0",
-    "fs-plus": "^2.0.0",
-    "pathwatcher": "^4.3",
-    "temp": "^0.8.0",
-    "underscore-plus": "^1.0.0",
-    "wrench": "^1.5.0"
+    "atom-space-pen-views": "^2.1.0",
+    "fs-plus": "^2.8.1",
+    "pathwatcher": "^6.3.0",
+    "temp": "^0.8.3",
+    "underscore-plus": "^1.6.6",
+    "wrench": "^1.5.8"
   }
 }


### PR DESCRIPTION
I couldn't install `svg-preview` anymore, so I updated all dependencies, which fixed the issue for me.

Atom 1.2.0
OS X 10.11.1